### PR TITLE
Change developer guide URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The source code of a sample application (JWPlayer_Developer_Demo) is included to
 JW Player Quickstart Guide
 ==========================
 
-- https://developer.jwplayer.com/sdk/ios/docs/developer-guide/intro/getting-started/
+- https://developer.jwplayer.com/sdk/ios/docs/developer-guide/
 
 JW Player iOS SDK Documentation
 =====================


### PR DESCRIPTION
@karimMourra @AmitaiB @henryhlee 

I am not sure who owns this repo, but can one of you approve and merge this URL change?

Changed the JW Player Quickstart Guide to the general dev guide URL: https://developer.jwplayer.com/sdk/ios/docs/developer-guide/