### PR TITLE
Amitai b patch 1

### DIFF
--- a/JWPlayer-SDK-iOS-Demo/ObjCViewController.m
+++ b/JWPlayer-SDK-iOS-Demo/ObjCViewController.m
@@ -23,7 +23,7 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     
-    JWConfig *config = [JWConfig configWithContentURL:@""];
+    JWConfig *config = [JWConfig configWithContentURL:@"http://content.bitsontherun.com/videos/3XnJSIm4-injeKYZS.mp4"];
     self.player = [[JWPlayerController alloc]initWithConfig:config];
 }
 


### PR DESCRIPTION
It appears this was a typo-of-omission. I copied the URL @karimMourra supplied in the Swift implementation's view controller here in the ObjC implementation.

Without this, the Objective-C implementation's player instance error's out.